### PR TITLE
Added message for replaced items(untested)

### DIFF
--- a/JeroenArsenal/fn_loadInventory.sqf
+++ b/JeroenArsenal/fn_loadInventory.sqf
@@ -458,29 +458,29 @@ _arrayRemove = [_arrayTaken, _arrayPlaced] call _subtractArrays;
 _arrayAdd call jna_fnc_addItems_Arsanal;
 _arrayRemove call jna_fnc_removeItems_Arsanal;
 
-_reportString = "";
-{
-	_index = _foreachindex;
-	_item = _x select 0;
-	_amount = _x select 1;
-	_xCfg = switch _index do {
-		case IDC_RSCDISPLAYARSENAL_TAB_BACKPACK:	{configfile >> "cfgvehicles" 	>> _item};
-		case IDC_RSCDISPLAYARSENAL_TAB_GOGGLES:		{configfile >> "cfgglasses" 	>> _item};
-		case IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG;
-		case IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL;
-		case IDC_RSCDISPLAYARSENAL_TAB_CARGOTHROW;
-		case IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT: 	{configfile >> "cfgmagazines" 	>> _item};
-		case IDC_RSCDISPLAYARSENAL_TAB_CARGOMISC:	{configfile >> "cfgweapons" 	>> _item};
-		default										{configfile >> "cfgweapons" 	>> _item};
-	};
-	_displayName = gettext (_xCfg >> "displayName");
-	if(_displayName isEqualTo "")then{_displayName = _item};
-	_reportString = _reportString + _displayName + " ("+(str _amount)+")\n";
-} forEach _arrayMissing;
+//create text for missing and replaced items
+//we could use ingame names here but some items might not be ingame(disabled mod), but if you feel like it you can still add it.
 
-if(_reportString != "")then{
-	titleText[("I couldn't find the following items:\n" + _reportString), "PLAIN"];
+_reportReplaced = "";
+{
+	_nameNew = _x select 0;
+	_nameOld = _x select 1;
+	_reportReplaced = _reportReplaced + _nameOld + " replaced with " + _nameNew + "\n";
+} forEach _arrayReplaced;
+
+_reportMissing = "";
+{
+	_name = _x select 0;
+	_amount = _x select 1;
+	_reportMissing = _reportMissing + _name + " (" + (str _amount) + "x)\n";
+}forEach _reportMissing;
+
+_reportTotal = _reportReplaced + _reportMissing;
+if(_reportTotal != "")then{
+	_reportTotal = ("I couldn't find the following items:\n" + _reportTotal);
+	titleText[_reportTotal, "PLAIN"];
 };
+
 
 
 /*


### PR DESCRIPTION
Quick untested change might need some minor testing!

Forgot to add this, shows message when player has item 1 and tries to load a loadout with item 2, if item 2 is not in the crate item 2 is replaced by item 1. This is only the case with Vest, Backpack and Uniforms.